### PR TITLE
Fix Swagger docs reload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,11 @@ app.post('/configure', async (req, res) => {
   }
 });
 
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(swagger));
+app.get('/swagger.json', (req, res) => {
+  res.json(swagger);
+});
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(null, { swaggerUrl: '/swagger.json' }));
 
 app.listen(config.port, () => {
   console.log('Server listening on port ' + config.port);


### PR DESCRIPTION
## Summary
- expose `/swagger.json` for dynamic Swagger spec
- configure docs to fetch `/swagger.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685365ee262c832fa195b050ac20163e