### PR TITLE
Add global JWT security for Swagger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,16 @@ let schema = {};
 const swagger = {
   openapi: '3.0.0',
   info: { title: 'Elite API Explorer', version: '1.0.0' },
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+    },
+  },
+  security: [{ bearerAuth: [] }],
   paths: {},
 };
 


### PR DESCRIPTION
## Summary
- configure Swagger UI to use bearer token auth

## Testing
- `node src/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68536e6a3fbc832f928448286215aff3