### PR TITLE
Switch to Redoc for API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ APIBuilder is an API generator for SQL Server. It provides a sleek React + Tailw
 - React interface allows selecting tables, columns and aliases
 - Generates versioned RESTful endpoints with JWT or API key security
 - Optional rate limiting middleware
-- Automatically publishes Swagger documentation
+- Automatically publishes API documentation with Redoc
 - Saves generated CRUD snippets in the `generated/` folder
 
 ## Usage
@@ -23,7 +23,7 @@ APIBuilder is an API generator for SQL Server. It provides a sleek React + Tailw
    ```bash
    npm start
    ```
-    Open `http://localhost:3000/` to launch the builder UI. After generating the API, docs are available at `http://localhost:3000/docs`.
+    Open `http://localhost:3000/` to launch the builder UI. After generating the API, docs are available at `http://localhost:3000/docs` using Redoc.
     The configuration used is saved under `configs/` and a code snippet for each
     table is written to `generated/`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "express-rate-limit": "^6.7.0",
         "jsonwebtoken": "^9.0.1",
         "mssql": "^9.3.1",
-        "swagger-ui-express": "^4.6.3"
+        "redoc-express": "^2.1.0"
       }
     },
     "node_modules/@azure-rest/core-client": {
@@ -412,13 +412,6 @@
       "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.5.tgz",
       "integrity": "sha512-3zwefSMwHpu8iVUW8YYz227sIv6UFqO31p1Bf1ZH/Vom7CmNyUsXjDBlnNzcuhmOL1XfxZ3nvND42kR23XlbcQ==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@tediousjs/connection-string": {
       "version": "0.5.0",
@@ -2322,6 +2315,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redoc-express": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/redoc-express/-/redoc-express-2.1.0.tgz",
+      "integrity": "sha512-gq6FvghNirD3dCJ7w8Z6escXYHnU1Hk50baQsIeGunQQ9YRoy6qR/MjEOJtDEKaPNB2NgkIzQ9ESNX5/27zkDA==",
+      "license": "MIT"
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -2739,30 +2738,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/swagger-ui-dist": {
-      "version": "5.25.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.25.2.tgz",
-      "integrity": "sha512-V4JyoygUe5nCbn7bAD0fVKSC0yNcL3ROIQtGC7M0NATKuyosCSmMU6T0yDZIIuGpSxjsjZh/D2Ejb8lnF2jjxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scarf/scarf": "=1.4.0"
-      }
-    },
-    "node_modules/swagger-ui-express": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
-      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
-      "license": "MIT",
-      "dependencies": {
-        "swagger-ui-dist": ">=4.11.0"
-      },
-      "engines": {
-        "node": ">= v0.10.32"
-      },
-      "peerDependencies": {
-        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tarn": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "dotenv": "^16.5.0",
     "jsonwebtoken": "^9.0.1",
     "express-rate-limit": "^6.7.0",
-    "swagger-ui-express": "^4.6.3"
+    "redoc-express": "^2.1.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const path = require('path');
 const rateLimit = require('express-rate-limit');
-const swaggerUi = require('swagger-ui-express');
+const redoc = require('redoc-express');
 const config = require('./config');
 const { loadSchema } = require('./db');
 const { createCrud } = require('./apiGenerator');
@@ -90,26 +90,33 @@ app.get('/swagger.json', (req, res) => {
   res.json(swagger);
 });
 
-const swaggerUiOptions = {
-  swaggerUrl: '/swagger.json',
-  explorer: true,
-  customSiteTitle: 'Elite API Explorer',
-  customCss: `
-    .swagger-ui .topbar {
-      background-color: #0f172a;
-    }
-    .swagger-ui .topbar .link, .swagger-ui .topbar .link:visited {
-      color: #fff;
-      font-weight: bold;
-      font-size: 1.25rem;
-    }
-    .swagger-ui .info hgroup.main h2, .swagger-ui .info hgroup.main a {
-      font-size: 2rem;
-      font-weight: 700;
-    }
-  `,
-};
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(null, swaggerUiOptions));
+app.get('/docs',
+  redoc({
+    title: 'Elite API Explorer',
+    specUrl: '/swagger.json',
+    redocOptions: {
+      scrollYOffset: 50,
+      theme: {
+        colors: {
+          primary: { main: '#E6007A' },
+          text: { primary: '#212121', secondary: '#212121' },
+        },
+        sidebar: {
+          backgroundColor: '#212121',
+          textColor: '#FFFFFF',
+          activeTextColor: '#F5F5DC',
+        },
+        rightPanel: {
+          backgroundColor: '#F5F5DC',
+          textColor: '#212121',
+        },
+        typography: {
+          fontFamily: 'Inter, sans-serif',
+        },
+      },
+    },
+  })
+);
 
 (async () => {
   const codeDir = path.join(__dirname, '..', 'configs');


### PR DESCRIPTION
## Summary
- replace `swagger-ui-express` with `redoc-express`
- serve `/swagger.json` and render docs at `/docs` using Redoc
- add Redoc theme using charcoal, magenta, biscuit and white
- document new docs in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685370b74918832fb73f11d1bab5e619